### PR TITLE
tighten dependency to match exact version of VirtualBox

### DIFF
--- a/VirtualBox.ExtensionPack/VirtualBox.ExtensionPack.nuspec
+++ b/VirtualBox.ExtensionPack/VirtualBox.ExtensionPack.nuspec
@@ -26,7 +26,7 @@
     <iconUrl>https://cdn.rawgit.com/michaelray/ChocolateyPackages/e2175ceeefe2c057a30e44e34575ece57f076da6/VirtualBox.ExtensionPack/VirtualBox_logo.png</iconUrl>
     <packageSourceUrl>https://github.com/michaelray/ChocolateyPackages</packageSourceUrl>
     <dependencies>
-      <dependency id="VirtualBox" version="[5,6)" />
+      <dependency id="VirtualBox" version="[5.1.6.110634]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
The extension pack should match exact same version of VirtualBox. Otherwise, you get VM's that won't start or VirtualBox prompts you to upgrade